### PR TITLE
redirect the redcap errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # pigeon 1.0.0
 Pigeon brings your records to redcap.
+
+Pigeon will print its log to stdout by default
+and any errors it comes across to stderr.

--- a/pigeon/redcap_errors.py
+++ b/pigeon/redcap_errors.py
@@ -1,3 +1,4 @@
+import sys
 from .exceptions import *
 
 def clean_error(error):
@@ -11,7 +12,7 @@ def clean_error(error):
     }
 
 def parse_errors(error_data):
-    print(error_data)
+    print(error_data, file=sys.stderr)
     if 'There were errors with your request.' in error_data:
         raise IrrecoverableError(error_data)
     if 'data being misformatted' in error_data:


### PR DESCRIPTION
This change is to help differentiate the json output with the errors found during processing. We can capture the errors and json independent of each other now. 
We will need to update the run.sh scripts in redi2 to accommodate this.